### PR TITLE
Pause bot if last user disconnects from server

### DIFF
--- a/plugins/control.rb
+++ b/plugins/control.rb
@@ -22,6 +22,10 @@ class Control < Plugin
       @@bot[:cli].on_user_state do |msg|
         userstate(msg)
       end
+      # Register for user disconnections
+      @@bot[:cli].on_user_remove do |msg|
+        state_handling_if_alone
+      end
     end
 
     state_handling_if_alone


### PR DESCRIPTION
When disconnecting from the server while being in the same channel as the bot, the bot continues to play and won't enter idle state.